### PR TITLE
Include juneteenth as a federal holiday

### DIFF
--- a/Data/Time/Calendar/BankHoliday/UnitedStates.hs
+++ b/Data/Time/Calendar/BankHoliday/UnitedStates.hs
@@ -31,6 +31,7 @@ bankHolidays year = filterHistoric standardHolidays
       , 3 `weeksAfter` firstThursdayIn nov -- thanksgiving
       ] ++ catMaybes [
         weekendHolidayFrom (jan 1)  -- newYearsDay
+      , filterHistoricAndGetClosestWeekday (jun 19) -- juneteenth
       , weekendHolidayFrom (jul 4)  -- independenceDay
       , weekendHolidayFrom (nov 11) -- veteransDay
       , weekendHolidayFrom (dec 25) -- christmas
@@ -77,3 +78,12 @@ firstDayOfWeekOnAfter :: DayOfWeek -> Day -> Day
 firstDayOfWeekOnAfter dw d = if dayOfWeek d == dw 
     then d 
     else firstDayOfWeekOnAfter dw  (addDays 1 d)
+
+-- Juneteenth came into effect in 2021
+filterHistoricAndGetClosestWeekday :: Day -> Maybe Day
+filterHistoricAndGetClosestWeekday d
+  | d < fromGregorian 2021 1 1 = Nothing
+  | otherwise = case weekIndex d of
+    3 -> Just (addDays (-1) d) -- if saturday, use friday
+    4 -> Just (addDays 1 d) -- if sunday, use monday
+    _ -> Just d -- this is a weekday

--- a/test/Data/Time/Calendar/BankHoliday/UnitedStatesSpec.hs
+++ b/test/Data/Time/Calendar/BankHoliday/UnitedStatesSpec.hs
@@ -30,6 +30,21 @@ spec = do
                   ]
       (sort (bankHolidays 2017)) `shouldBe` dates
 
+    it "gets all dates in 2021 correct" $ do
+      let year = fromGregorian 2021
+      let dates = [ year 1 1
+                  , year 1 18
+                  , year 2 15
+                  , year 5 31
+                  , year 6 18
+                  , year 7 5
+                  , year 9 6
+                  , year 10 11
+                  , year 11 11
+                  , year 11 25
+                  ]
+      (sort (bankHolidays 2021)) `shouldBe` dates
+
     it "do not include dates before the inception of bank holidays" $ do
       (bankHolidays 1932) `shouldBe` []
 


### PR DESCRIPTION
Including juneteenth as a federal holiday. The logic for this holiday is 
- Is the date after - 1 Jan 2021
- If June 19 falls on a saturday use the friday as holiday
- If June 19 falls on a sunday, use the monday as holiday
- else use June 19 as-is as its on a weekday